### PR TITLE
feat: allow boj open command run without id

### DIFF
--- a/boj/args_resolver.py
+++ b/boj/args_resolver.py
@@ -66,6 +66,8 @@ def add_open_parser(subparsers):
     problem_parser.add_argument(
         "problem_id",
         metavar="PROBLEM_ID",
+        default=None,
+        nargs='?',
         type=int,
         help="problem id",
     )

--- a/boj/commands/open/open_command.py
+++ b/boj/commands/open/open_command.py
@@ -2,12 +2,24 @@ import webbrowser
 
 import boj.core.constant
 from boj.core.base import Command
-from boj.core.config import Config
 from boj.core.out import BojConsole
+from boj.core.config import Config
+from boj.data.boj_info import BojInfo
 
 
 class OpenCommand(Command):
     def execute(self, args):
         console = BojConsole()
         with console.status("Opening in browser..."):
-            webbrowser.open(boj.core.constant.boj_problem_url(args.problem_id))
+            problem_id = None
+            if args.problem_id:
+                problem_id = args.problem_id
+            else:
+                config = Config.load()
+                boj_info = BojInfo.find_any(
+                    problem_dir=config.workspace.problem_dir,
+                    problem_id=None
+                )
+                problem_id = boj_info.id
+
+            webbrowser.open(boj.core.constant.boj_problem_url(problem_id))

--- a/boj/commands/run/run_command.py
+++ b/boj/commands/run/run_command.py
@@ -5,7 +5,6 @@ from boj.core.base import Command
 from boj.core.config import Config
 from boj.core.out import BojConsole
 from boj.data.boj_info import BojInfo
-from boj.core.error import IllegalStatementError, ResourceNotFoundError
 from boj.data.solution import Solution
 from boj.data.testcase import TomlTestcase
 


### PR DESCRIPTION
We can get the problem id from .boj-info.json in case that we run `boj open` in the problem directory.