### PR TITLE
fix: resolve config key mismatch between README and code

### DIFF
--- a/boj/data/config.py
+++ b/boj/data/config.py
@@ -126,7 +126,7 @@ class FiletypeConfig:
             ongoing_dir=ongoing_dir,
             filetype=filetype,
             language=data.get("language", None),
-            main=data.get("main") or data.get("filename") or f"main.{filetype}",
+            main=data.get("main", f"main.{filetype}"),
             source_dir=data.get("source_dir", ""),
             compile_=data.get("compile", None),
             run=data.get("run", None),
@@ -139,7 +139,7 @@ class FiletypeConfig:
             raise FatalError(f"missing 'language' option for the filetype {filetype}")
 
         if not config.main:
-            raise FatalError(f"missing 'filename' option for the filetype {filetype}")
+            raise FatalError(f"missing 'main' option for the filetype {filetype}")
 
         if not config.run:
             raise FatalError(f"missing 'run' option for the filetype {filetype}")

--- a/boj/data/config.py
+++ b/boj/data/config.py
@@ -126,7 +126,7 @@ class FiletypeConfig:
             ongoing_dir=ongoing_dir,
             filetype=filetype,
             language=data.get("language", None),
-            main=data.get("filename", f"main.{filetype}"),
+            main=data.get("main") or data.get("filename") or f"main.{filetype}",
             source_dir=data.get("source_dir", ""),
             compile_=data.get("compile", None),
             run=data.get("run", None),


### PR DESCRIPTION
- 문제 및 현상
    - 속성 키 불일치: `config.yaml`의 메인 파일명 설정 키가 README(`main`)와 실제 코드(`filename`)에서 서로 다릅니다.
    - 설정 무시 현상: README 가이드대로 `main: "solution.py"`를 설정해도, 실제로는 기본값인 `main.{filetype}`으로 파일이 생성됩니다.
- 원인
    - boj/data/config.py:129 `data.get("filename", ...)` 으로 `filename` 키만 조회하도록 구현되어 있어, 사용자가 설정한 `main` 키값을 찾지 못하고 기본값을 사용하고 있습니다.
- 고려해 본 개선 방안들
    - (방안 1) 코드에 맞춰 README 수정 (`main:` → `filename:`)
        - 장점: 코드 변경이 없으므로 사이드 이펙트가 없습니다.
        - 단점: 기존 `main` 사용자의 설정이 여전히 동작하지 않으며, `main`보다 명칭의 직관성이 떨어집니다.
    - (방안 2) README에 맞춰 코드 수정 (`filename` → `main`)
        - 장점: 문서와 코드가 일치하며, '메인 파일'이라는 의미가 명확히 전달할 수 있습니다.
        - 단점: 기존에 `filename` 속성을 파악해 사용하던 사용자의 설정이 깨지게 됩니다.
    - (방안 3) 하위 호환성을 고려한 코드 수정
        - 방법: `main=data.get("main") or data.get("filename") or f"main.{filetype}"`
        - 장점: 기존 사용자(`filename`)와 신규 사용자(`main`) 모두 지원 가능하며, 가독성 높은 속성 이름을 유지할 수 있습니다.
        - 단점: 동일 역할의 속성이 두 개 존재하게 되어 향후 코드 유지보수 시 주의가 필요합니다.
- 최종 선택한 개선 방안
    - **(방안 3) 하위 호환성을 고려한 코드 수정**
        - 선택한 이유: 문제를 해결하면서도 기존 환경을 유지할 수 있는 안전한 방식이라고 생각합니다.
        - NIT: 장기적으로는 filename 지원을 완전히 제거하고 main만 지원하는 방향 등을 고려해 볼 수도 있겠습니다.
- 테스트: 변경 로직만 추출하여 로컬 환경에서 별도의 테스트로 진행했습니다.
    ```python
    # test_main.py
    
    # FiletypeConfig.of의 main 파싱 로직만 추출하여 테스트
    def get_main(data, filetype):
        return data.get("main") or data.get("filename") or f"main.{filetype}"
    
    # 1. main 속성만 있는 경우
    assert get_main({'main': 'solution.py'}, 'py') == 'solution.py'
    print('PASS: main 속성 -> solution.py')
    
    # 2. filename 속성만 있는 경우
    assert get_main({'filename': 'answer.py'}, 'py') == 'answer.py'
    print('PASS: filename 속성 -> answer.py')
    
    # 3. 둘 다 없는 경우
    assert get_main({}, 'py') == 'main.py'
    print('PASS: 기본값 -> main.py')
    
    # 4. 둘 다 있는 경우 (main 우선)
    assert get_main({'main': 'solution.py', 'filename': 'answer.py'}, 'py') == 'solution.py'
    print('PASS: 둘 다 있을 때 -> solution.py (main 우선)')
    
    print('\nALL PASS!')
    ```
    <img width="725" height="141" alt="image" src="https://github.com/user-attachments/assets/48e99217-e9d8-429d-a7de-533219e11ecc" />
